### PR TITLE
docs: updated user guides for new users (Week 1 audit)

### DIFF
--- a/src/routes/pages/en/guides/bitcoin-wallet.md
+++ b/src/routes/pages/en/guides/bitcoin-wallet.md
@@ -1,0 +1,92 @@
+---
+title: Your Bitcoin Wallet
+description: Send and receive Bitcoin instantly using Lightning or on-chain with the Flash app.
+---
+
+Flash gives you a Bitcoin wallet powered by the Lightning Network. You can send and receive Bitcoin instantly, with low fees, directly from your phone.
+
+---
+
+## Receiving Bitcoin
+
+### Lightning (Recommended)
+
+1. Open the Flash app and tap **Receive**
+2. Your Lightning invoice and QR code will appear
+3. Share the QR code or copy the invoice to send to the payer
+4. Bitcoin arrives in your wallet instantly once paid
+
+### On-Chain Bitcoin
+
+For senders using a standard Bitcoin wallet (not Lightning):
+
+1. Tap **Receive** in the Flash app
+2. Tap the receive type selector and choose **On-Chain**
+3. Share your Bitcoin address or QR code
+4. Funds arrive after network confirmations — typically 10–60 minutes
+
+> 💡 **Tip:** Lightning is faster and cheaper for most payments. Use on-chain only when the sender requires it.
+
+---
+
+## Sending Bitcoin
+
+1. Tap **Send** in the Flash app
+2. Paste a Lightning invoice, scan a QR code, or enter a Flash username
+3. Review the amount and fee
+4. Tap **Confirm** to send
+
+Lightning payments are instant. On-chain sends may take 10–60 minutes to confirm.
+
+---
+
+## Unclaimed Deposits
+
+Sometimes an on-chain deposit cannot be claimed automatically — for example, if network fees spike above the deposit amount, or if there is a missing transaction issue. These appear in the app as **Unclaimed Deposits**.
+
+### How to find them
+
+Go to your transaction list — unclaimed deposits appear with a status indicator:
+- 🟡 **Auto-claiming** — the app is processing it automatically, no action needed
+- 🟠 **Approval required** — fee is higher than expected, you need to approve it
+- 🔴 **Claim failed** — needs manual action
+
+### Approval Required
+
+If a deposit shows "Approval Required":
+
+1. Tap **Details** on the deposit
+2. Review the fee breakdown — you'll see the deposit amount, network fee, and what you'll receive
+3. Tap **Approve** to claim (the network fee is deducted from your deposit)
+4. Or tap **Refund** to send the funds to an external wallet instead
+
+### Claim Failed
+
+If a deposit shows "Claim Failed":
+
+1. Tap **Details**
+2. Review the error message
+3. Tap **Refund** to recover funds to an external Bitcoin wallet
+
+### No unclaimed deposits?
+
+If you believe you sent a payment that has not arrived, contact Flash support with the transaction ID and amount.
+
+---
+
+## Troubleshooting
+
+**"Wallet is offline"**
+Check your internet connection and reopen the app. Your balance is safe — it will display correctly once reconnected.
+
+**My Lightning payment has not arrived**
+Lightning payments are usually instant. If it has been more than a few minutes, contact support with the invoice details.
+
+**What is the difference between Lightning and on-chain?**
+Lightning is instant and nearly free — best for everyday payments. On-chain is slower with higher fees but works with any Bitcoin wallet. Flash supports both.
+
+---
+
+## Need Help?
+
+Contact Flash support via the app.

--- a/src/routes/pages/en/guides/cash-out.md
+++ b/src/routes/pages/en/guides/cash-out.md
@@ -1,57 +1,69 @@
 ---
-title: Let's Get Physical!
-description: A step-by-step guide to turn your Flash wallet funds into physical cash.
+title: How to Cash Out
+description: Cash out your Flash balance to your Jamaican bank account.
 ---
 
-## Settle to Your Bank Account
+Cash out your Flash balance to your bank account. This guide covers both Pro and Merchant accounts.
 
-A Pro or Merchant account is required to settle directly from your Flash wallet to your Jamaican bank account. Do it quickly and easily with these steps:
+> **Note:** This process currently requires contacting support. Automated cashout is coming soon.
 
-#### Step 1: Initiate the transfer in your Flash app
+---
 
-1. Open your Flash app and press the "Settle" button on the home screen
-2. Enter the amount you want to transfer to your bank account
-3. Tap "Next" to proceed
-4. Review the transfer details and tap "Continue"
-5. Review the details of your settlement, including the fees and estimated arrival time
-6. Tap "Confirm" to start the process
+## Before You Begin
 
-#### Step 2: Receive your funds
+You need a **Level 2 Pro or Level 3 Merchant account**. If you have not upgraded yet, see [How to Upgrade Your Account](guides/upgrade-account).
 
-1. ACH transfers typically arrive within 0-1 business days
-2. RTGS transfers usually arrive the same day if initiated before 1:00 PM on business days
-3. You'll receive a notification on your Flash app when the transfer is processed
-4. Check your bank account to confirm receipt of the funds
+Cash out destinations:
+- **JMD** — any Jamaican bank account
+- **USD** — First Global Bank only
 
-_Note: Bank transfers are subject to standard banking hours and may be delayed during weekends or holidays. Bank minimum and maximum transfer limits may apply._
+---
 
-## Cash Out at a Flashpoint
+## Steps
 
-Any business that accepts Flash can be a "Flashpoint" — a member location that participates in our rewards program and provides services like cash out, top up, and point of sale transactions. Here's how to get physical cash:
+**1. Open Flash and send to Flash's account**
 
-### 1. Find a Flashpoint on the Map
+In the Flash app, tap **Send**. Search for the username **`flash`** and send the amount you want to cash out.
 
-Open your Flash app and go to the Maps tab. You'll see an interactive map showing all nearby member locations that offer Flash services.
-![Maps Tab](/images/badges/png/Screenshot-map.png)
+> ⚠️ Double-check the username is exactly `flash` before confirming. This transfers your balance to Flash for processing.
 
-### 2. Choose a Flashpoint Near You
+**2. Contact support**
 
-Flash has a wide network of member businesses ready to serve you. Each location participates in our rewards program and offers various services including cash out. You can find a complete list of member locations on our [Flashpoint Map](https://flashpoint.flashapp.me).
-![Flashpoint Map](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.lockedownseo.com%2Fwp-content%2Fuploads%2F2013%2F11%2Fadd-map-marker-google-maps.jpg&f=1&nofb=1&ipt=1e0378994a52e5316b86d378b31f725668d627bdfaffbaaf2d5f41a8d6777126&ipo=images)
+After sending, message Flash support and include:
+- Your Flash username
+- The amount you sent
+- Confirmation that the transfer was completed
 
-### 3. Visit the Flashpoint and Cash Out
+**3. Wait for processing**
 
-1. When you arrive at the member location request to cash out your Flash wallet funds
-2. The business will ask you to scan their QR code to initiate the cash out process
-3. Open your Flash app and tap the "Scan" button
-4. Scan the QR code provided by the business
-5. Enter the amount you want to cash out and tap "Send"
-6. The business will give you physical cash and you're done! 🤙
+Support will verify the transaction and initiate the bank transfer from Flash's account to yours.
 
-## Next steps
+**4. Receive your funds**
 
-Now you see how easy it is to turn your Flash funds into physical cash, you might be wondering what else you can do with bitcoin.
-Here are a few ideas:
+You will receive a confirmation from support with a reference code. Check your bank account for the deposit.
 
--   [Secure Your Cash: How to use Cold Storage](guides/sweep-to-cold-storage)
--   [Dollar Cost Averaging](guides/dca)
+**Transfer timelines (Jamaica):**
+- Submitted before 2:00 PM on a weekday → same day via RTGS
+- Submitted after 2:00 PM or on a weekend → next business day
+
+---
+
+## Fees
+
+| Account Level | Amount | Fee |
+|--------------|--------|-----|
+| Level 2 Pro | Any amount | 2% |
+| Level 3 Merchant | Under US$50,000 | 2% |
+| Level 3 Merchant | US$50,000 and above | 1% |
+
+Fees are deducted from the amount transferred to your bank.
+
+---
+
+## Need Help?
+
+Contact Flash support via the app.
+
+---
+
+> **Coming soon:** Automated cashout — complete the process in seconds without contacting support.

--- a/src/routes/pages/en/guides/top-up.md
+++ b/src/routes/pages/en/guides/top-up.md
@@ -1,0 +1,64 @@
+---
+title: How to Top Up
+description: Add funds to your Flash wallet via bank transfer or in person at a Flashpoint.
+---
+
+Add funds to your Flash wallet. Choose the method that works best for you.
+
+> **Note:** Bank transfer top-ups currently require contacting support to complete. Automated top-up is coming soon.
+
+---
+
+## Option 1: Bank Transfer (JMD)
+
+Transfer JMD from your Jamaican bank account to Flash.
+
+**Step 1: Make the bank transfer**
+
+Send funds to Flash's bank account:
+
+| Field | Details |
+|-------|---------|
+| Account Name | ISLAND BITCOIN JAMAICA LIMITED |
+| Bank | First Global Bank |
+| Account Number | 990858892950 |
+| Account Type | Savings |
+| Currency | JMD |
+| Branch | Liguanea |
+
+**Step 2: Contact support**
+
+After completing the transfer, message Flash support with:
+- Your Flash username
+- The amount transferred
+- Your bank transfer confirmation or reference number
+
+**Step 3: Funds credited**
+
+Support will verify the deposit and credit your Flash wallet. You'll receive a confirmation when it's done.
+
+**Processing time:** Same business day for transfers received during banking hours.
+
+---
+
+## Option 2: Top Up at a Flashpoint (In Person)
+
+Top up your Flash wallet in person at any Flashpoint merchant location using cash or card.
+
+1. Visit any Flashpoint location
+2. Tell the merchant you'd like to top up your Flash wallet
+3. Provide your Flash username
+4. Pay the amount in cash or by card
+5. Funds are credited to your Flash wallet on the spot
+
+Find your nearest Flashpoint on the Map tab in the Flash app.
+
+---
+
+## Need Help?
+
+Contact Flash support via the app.
+
+---
+
+> **Coming soon:** Instant top-up — add funds without contacting support.

--- a/src/routes/pages/en/guides/upgrade-account.md
+++ b/src/routes/pages/en/guides/upgrade-account.md
@@ -1,0 +1,80 @@
+---
+title: How to Upgrade Your Account
+description: Unlock higher limits and features like cashout by upgrading your Flash account.
+---
+
+Flash has four account levels. Upgrading unlocks higher limits and additional features like cashout and merchant tools.
+
+| Level | Name | Features |
+|-------|------|----------|
+| L0 | Trial | Basic wallet, send/receive Bitcoin |
+| L1 | Personal | Phone-verified, higher limits |
+| L2 | Pro | Cashout to bank, buy/sell Bitcoin |
+| L3 | Merchant | All Pro features + merchant tools, lower cashout fee |
+
+---
+
+## Level 0 → Level 1 (Trial → Personal)
+
+**What you need:** Your phone number
+
+1. Open the Flash app and go to **Settings → Account → Upgrade Account**
+2. Enter your phone number and verify with the code sent via SMS
+3. Upgrade completes instantly — no waiting required
+
+---
+
+## Level 1 → Level 2 (Personal → Pro)
+
+**What you need:** A valid government-issued ID and your bank account details
+
+1. Go to **Settings → Account → Upgrade Account**
+2. Complete your personal information
+3. Upload a photo of your government-issued ID
+   > 💡 **Tip:** Upload from your gallery rather than taking a photo directly — this is more reliable on Android
+4. Enter your banking information:
+   - Bank name
+   - Account number
+   - Account type
+   - Branch/location
+5. Submit your request
+
+**Approval:** Your application is reviewed by the Flash team. You'll be notified when approved.
+- **Expected time:** Usually within 8 hours (SLA: 48 hours)
+
+---
+
+## Level 2 → Level 3 (Pro → Merchant)
+
+**What you need:** Business/merchant information
+
+1. Go to **Settings → Account → Upgrade Account**
+2. Complete the additional merchant information fields
+3. Submit your request
+
+**Approval:** Same review process as Pro — usually within 8 hours.
+
+---
+
+## What Happens After You Apply
+
+- Your request will show as **Pending** while under review
+- You cannot submit another request while one is pending
+- If your request is **approved**, your account upgrades automatically and you'll be notified
+- If your request is **rejected**, you'll be notified with a reason — you can reapply immediately using the same button
+
+---
+
+## Troubleshooting
+
+**"Error submitting my banking information"**
+If you see an error when entering your bank account number, try using a shorter account number format. This is a known issue currently being fixed.
+
+**"My upgrade has been pending for more than 48 hours"**
+Contact Flash support via the app and they'll check the status of your application.
+
+---
+
+## Need Help?
+
+Contact Flash support via the app.


### PR DESCRIPTION
## Summary

Four guides updated/added as part of the Flash docs audit for new product users.

### Changes

**Updated:**
- `cash-out.md` — Completely rewritten. Old guide referenced a 'Settle' button and had wrong RTGS cutoff (1pm → 2pm). New guide reflects actual flow: send to `flash` username, contact support, receive bank transfer. Includes correct fee table for L2 Pro and L3 Merchant.

**New:**
- `top-up.md` — Bank transfer to FGB (ISLAND BITCOIN JAMAICA LIMITED) and in-person Flashpoint top-up
- `upgrade-account.md` — All 4 account levels, automated L0→L1, manual review for Pro/Merchant, SLA, rejection and reapply flow
- `bitcoin-wallet.md` — Lightning + on-chain send/receive, and Unclaimed Deposits flow (auto-claiming, approval required, claim failed) from the Breez SDK Spark migration

### Verification
All flows confirmed by Dread and verified against flash-mobile source code.