### PR TITLE
fix: add new guides to sidebar nav and locale strings

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -18,7 +18,10 @@
             links: [
                 { href: '/user-guides', localeString: 'nav.guidesOverview' },
                 { href: '/guides/get-cash', localeString: 'nav.getCash' },
+                { href: '/guides/top-up', localeString: 'nav.topUp' },
                 { href: '/guides/cash-out', localeString: 'nav.cashOut' },
+                { href: '/guides/upgrade-account', localeString: 'nav.upgradeAccount' },
+                { href: '/guides/bitcoin-wallet', localeString: 'nav.bitcoinWallet' },
                 { href: '/guides/earn', localeString: 'nav.earn' },
                 { href: '/guides/chat', localeString: 'nav.chat' },
                 { href: '/guides/contacts', localeString: 'nav.contacts' },

--- a/src/lib/locales/ar.json
+++ b/src/lib/locales/ar.json
@@ -54,6 +54,9 @@
         "guides": "أدلة المستخدمين",
         "guideIris": "Iris (عميل الويب)",
         "guideSweepSats": "النقل إلى التخزين البارد",
+        "topUp": "شحن الرصيد (تحويل بنكي)",
+        "upgradeAccount": "ترقية حسابك",
+        "bitcoinWallet": "محفظة البيتكوين"
         "whatIs": "مشروع Galoy",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/de.json
+++ b/src/lib/locales/de.json
@@ -54,6 +54,9 @@
         "guides": "Benutzerhandbücher",
         "guideIris": "Iris (Web-Client)",
         "guideSweepSats": "In Cold Storage übertragen",
+        "topUp": "Aufladen (Banküberweisung)",
+        "upgradeAccount": "Konto Upgraden",
+        "bitcoinWallet": "Bitcoin-Wallet"
         "whatIs": "Galoy-Projekt",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -54,6 +54,9 @@
         "guides": "User Guides",
         "guideIris": "Iris (Web Client)",
         "guideSweepSats": "Sweep to Cold Storage",
+        "topUp": "Top Up (Bank Transfer)",
+        "upgradeAccount": "Upgrade Your Account",
+        "bitcoinWallet": "Bitcoin Wallet",
         "whatIs": "Galoy Project",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -56,6 +56,9 @@
         "getNip05": "Obetener un NIP-05 Verificado",
         "guideFlashchat": "FlashChat (Cliente Chat)",
         "guideSweepSats": "Barrer a la auto-custodia"
+        "topUp": "Recargar (Transferencia Bancaria)",
+        "upgradeAccount": "Actualizar Tu Cuenta",
+        "bitcoinWallet": "Billetera Bitcoin"
     },
     "donateButton": "Donar a Flash",
     "colophon": "Hecho con 💜 & ⚡ por",

--- a/src/lib/locales/fa.json
+++ b/src/lib/locales/fa.json
@@ -28,6 +28,9 @@
         "getNip05": "بگیرید NIP-05 تایید",
         "guideFlashchat": "(کلاینت چت) ناسترچت",
         "guideSweepSats": "به سوی خود-متولی شدن بروید"
+        "topUp": "شارژ کیف پول (انتقال بانکی)",
+        "upgradeAccount": "ارتقاء حساب",
+        "bitcoinWallet": "کیف پول بیت‌کوین"
     },
     "donateButton": "Flash.how کمک مالی به",
     "colophon": " و ⚡ ساخته شده با 💜",

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -49,6 +49,9 @@
     "getNip05" : "Obtenir un NIP-05",
     "guideFlashchat" : "FlashChat (Client de messagerie instantanée)",
     "guideSweepSats" : "Détenir ses sats"
+        "topUp": "Recharger (Virement Bancaire)",
+        "upgradeAccount": "Mettre à Niveau Votre Compte",
+        "bitcoinWallet": "Portefeuille Bitcoin"
   },
   "donateButton" : "Don à Flash",
   "colophon" : "Fait avec 💜 et ⚡ par",

--- a/src/lib/locales/hi.json
+++ b/src/lib/locales/hi.json
@@ -54,6 +54,9 @@
         "guides": "उपयोगकर्ता गाइड",
         "guideIris": "Iris (वेब क्लाइंट)",
         "guideSweepSats": "कोल्ड स्टोरेज में स्थानांतरित करें",
+        "topUp": "टॉप अप (बैंक ट्रांसफर)",
+        "upgradeAccount": "अपना खाता अपग्रेड करें",
+        "bitcoinWallet": "बिटकॉइन वॉलेट"
         "whatIs": "Galoy प्रोजेक्ट",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -28,6 +28,9 @@
     "getNip05": "Ottenere la verifica NIP-05",
     "guideFlashchat": "FlashChat (Cliente Chat)",
     "guideSweepSats": "Spazzare per auto-custodia"
+        "topUp": "Ricarica (Bonifico Bancario)",
+        "upgradeAccount": "Aggiorna Il Tuo Account",
+        "bitcoinWallet": "Portafoglio Bitcoin"
   },
   "donateButton": "Dona a Flash.how",
   "colophon": "Fatto con 💜 & ⚡ da",

--- a/src/lib/locales/ja.json
+++ b/src/lib/locales/ja.json
@@ -54,6 +54,9 @@
         "guides": "ユーザーガイド",
         "guideIris": "Iris（ウェブクライアント）",
         "guideSweepSats": "コールドストレージへ移動",
+        "topUp": "チャージ（銀行振込）",
+        "upgradeAccount": "アカウントのアップグレード",
+        "bitcoinWallet": "ビットコインウォレット"
         "whatIs": "Galoyプロジェクト",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/ko.json
+++ b/src/lib/locales/ko.json
@@ -54,6 +54,9 @@
         "guides": "사용자 가이드",
         "guideIris": "Iris (웹 클라이언트)",
         "guideSweepSats": "콜드 스토리지로 이동",
+        "topUp": "충전 (계좌 이체)",
+        "upgradeAccount": "계정 업그레이드",
+        "bitcoinWallet": "비트코인 지갑"
         "whatIs": "Galoy 프로젝트",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -54,6 +54,9 @@
         "guides": "Gebruikershandleidingen",
         "guideIris": "Iris (Web Client)",
         "guideSweepSats": "Overzetten naar cold storage",
+        "topUp": "Opwaarderen (Bankoverschrijving)",
+        "upgradeAccount": "Account Upgraden",
+        "bitcoinWallet": "Bitcoin-portemonnee"
         "whatIs": "Galoy Project",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/pt.json
+++ b/src/lib/locales/pt.json
@@ -54,6 +54,9 @@
         "guides": "Guias do Usuário",
         "guideIris": "Iris (Cliente Web)",
         "guideSweepSats": "Transferir para Armazenamento Frio",
+        "topUp": "Recarregar (Transferência Bancária)",
+        "upgradeAccount": "Atualizar Sua Conta",
+        "bitcoinWallet": "Carteira Bitcoin"
         "whatIs": "Projeto Galoy",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/sw.json
+++ b/src/lib/locales/sw.json
@@ -54,6 +54,9 @@
         "guides": "Miongozo ya Watumiaji",
         "guideIris": "Iris (Mteja wa Wavuti)",
         "guideSweepSats": "Hamisha kwenye Cold Storage",
+        "topUp": "Ongeza Fedha (Uhamisho wa Benki)",
+        "upgradeAccount": "Boresha Akaunti Yako",
+        "bitcoinWallet": "Pochi ya Bitcoin"
         "whatIs": "Mradi wa Galoy",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"

--- a/src/lib/locales/zh.json
+++ b/src/lib/locales/zh.json
@@ -54,6 +54,9 @@
         "guides": "用户指南",
         "guideIris": "Iris（网页客户端）",
         "guideSweepSats": "转移到冷存储",
+        "topUp": "充值（银行转账）",
+        "upgradeAccount": "升级您的账户",
+        "bitcoinWallet": "比特币钱包"
         "whatIs": "Galoy 项目",
         "whyWeNeed": "Breez SDK",
         "whatZaps": "IBEX Mercado"


### PR DESCRIPTION
## Problem
The three new guides (top-up, upgrade-account, bitcoin-wallet) were added as markdown files but not registered in the sidebar nav or locale files, causing 404s and missing menu items.

## Fix
- **Sidebar.svelte:** Added nav links for `/guides/top-up`, `/guides/upgrade-account`, `/guides/bitcoin-wallet`
- **All 14 locale files (en, es, fr, pt, de, it, nl, ar, fa, hi, ja, ko, sw, zh):** Added `nav.topUp`, `nav.upgradeAccount`, `nav.bitcoinWallet` keys with translated labels

## After merging
All three new guides will appear in the left sidebar and resolve correctly.