### PR TITLE
seo: add robots.txt, sitemap.xml, and OpenGraph/Twitter Card meta tags

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,6 +14,17 @@
         <!-- <meta name="viewport" content="width=device-width" /> -->
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+        <!-- Site-wide social/SEO defaults. Per-page <svelte:head> blocks
+             override og:title / og:description / og:url / canonical. -->
+        <meta property="og:site_name" content="Flash Documentation" />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content="https://documentation.getflash.io/android-chrome-512x512.png" />
+        <meta property="og:image:width" content="512" />
+        <meta property="og:image:height" content="512" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@getflashio" />
+        <meta name="twitter:image" content="https://documentation.getflash.io/android-chrome-512x512.png" />
+
         %sveltekit.head%
     </head>
     <body

--- a/src/routes/[locale=locale]/+page.svelte
+++ b/src/routes/[locale=locale]/+page.svelte
@@ -51,6 +51,16 @@
 <svelte:head>
     <title>Flash Docs</title>
     <meta name="description" content="Flash Docs helps Caribbean users get started with Cash Wallet, Bitcoin Wallet, Swap, top ups, cash outs, and merchant tools." />
+    <link rel="canonical" href="https://documentation.getflash.io/" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Flash Documentation" />
+    <meta property="og:description" content="Flash Docs helps Caribbean users get started with Cash Wallet, Bitcoin Wallet, Swap, top ups, cash outs, and merchant tools." />
+    <meta property="og:url" content="https://documentation.getflash.io/" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:title" content="Flash Documentation" />
+    <meta name="twitter:description" content="Flash Docs helps Caribbean users get started with Cash Wallet, Bitcoin Wallet, Swap, top ups, cash outs, and merchant tools." />
 </svelte:head>
 
 {#if mounted}

--- a/src/routes/[locale=locale]/[slug]/+page.svelte
+++ b/src/routes/[locale=locale]/[slug]/+page.svelte
@@ -26,13 +26,31 @@
 <svelte:head>
     <title>{data.title} - Flash Documentation</title>
     <meta name="description" content={data.description} />
+    <link rel="canonical" href="https://documentation.getflash.io/{$locale}/{data.slug}" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="{data.title} - Flash Documentation" />
+    <meta property="og:description" content={data.description} />
+    <meta property="og:url" content="https://documentation.getflash.io/{$locale}/{data.slug}" />
+    <meta property="og:locale" content={$locale} />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:title" content="{data.title} - Flash Documentation" />
+    <meta name="twitter:description" content={data.description} />
+
+    <!-- hreflang alternates for sibling translations -->
     {#each otherLocales as supportedLocale}
         <link
             rel="alternate"
             hreflang={supportedLocale}
-            href="https://flash.how/{supportedLocale}/{data.slug}"
+            href="https://documentation.getflash.io/{supportedLocale}/{data.slug}"
         />
     {/each}
+    <link
+        rel="alternate"
+        hreflang="x-default"
+        href="https://documentation.getflash.io/en/{data.slug}"
+    />
 </svelte:head>
 
 {#if mounted}

--- a/src/routes/[locale=locale]/guides/[slug]/+page.svelte
+++ b/src/routes/[locale=locale]/guides/[slug]/+page.svelte
@@ -27,13 +27,31 @@
 <svelte:head>
     <title>{data.title} - Flash Documentation</title>
     <meta name="description" content={data.description} />
+    <link rel="canonical" href="https://documentation.getflash.io/{$locale}/guides/{data.slug}" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="{data.title} - Flash Documentation" />
+    <meta property="og:description" content={data.description} />
+    <meta property="og:url" content="https://documentation.getflash.io/{$locale}/guides/{data.slug}" />
+    <meta property="og:locale" content={$locale} />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:title" content="{data.title} - Flash Documentation" />
+    <meta name="twitter:description" content={data.description} />
+
+    <!-- hreflang alternates for sibling translations -->
     {#each otherLocales as supportedLocale}
         <link
             rel="alternate"
             hreflang={supportedLocale}
-            href="https://flash.how/{supportedLocale}/guides/{data.slug}"
+            href="https://documentation.getflash.io/{supportedLocale}/guides/{data.slug}"
         />
     {/each}
+    <link
+        rel="alternate"
+        hreflang="x-default"
+        href="https://documentation.getflash.io/en/guides/{data.slug}"
+    />
 </svelte:head>
 
 {#if mounted}

--- a/src/routes/[locale=locale]/training/[slug]/+page.svelte
+++ b/src/routes/[locale=locale]/training/[slug]/+page.svelte
@@ -27,13 +27,31 @@
 <svelte:head>
     <title>{data.title} - Flash Documentation</title>
     <meta name="description" content={data.description} />
+    <link rel="canonical" href="https://documentation.getflash.io/{$locale}/training/{data.slug}" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="{data.title} - Flash Documentation" />
+    <meta property="og:description" content={data.description} />
+    <meta property="og:url" content="https://documentation.getflash.io/{$locale}/training/{data.slug}" />
+    <meta property="og:locale" content={$locale} />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:title" content="{data.title} - Flash Documentation" />
+    <meta name="twitter:description" content={data.description} />
+
+    <!-- hreflang alternates for sibling translations -->
     {#each otherLocales as supportedLocale}
         <link
             rel="alternate"
             hreflang={supportedLocale}
-            href="https://flash.how/{supportedLocale}/training/{data.slug}"
+            href="https://documentation.getflash.io/{supportedLocale}/training/{data.slug}"
         />
     {/each}
+    <link
+        rel="alternate"
+        hreflang="x-default"
+        href="https://documentation.getflash.io/en/training/{data.slug}"
+    />
 </svelte:head>
 
 {#if mounted}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,101 @@
+import type { RequestHandler } from './$types';
+import { supportedLocales } from '$lib/config/l10n';
+
+// Build a list of all markdown pages at compile time. Vite's import.meta.glob
+// gives us a static map of every .md file under src/routes/pages, which lets
+// the sitemap stay in sync with the actual content without any runtime FS work.
+const pageModules = import.meta.glob('/src/routes/pages/**/*.md');
+
+// Site URL is overridable via env (PUBLIC_SITE_URL) so deploy previews can use
+// their own host. Defaults to the production docs domain.
+const SITE_URL = (import.meta.env.PUBLIC_SITE_URL ?? 'https://documentation.getflash.io').replace(/\/$/, '');
+
+interface SitemapEntry {
+    loc: string;
+    alternates: { hreflang: string; href: string }[];
+}
+
+function buildEntries(): SitemapEntry[] {
+    // Map of slug -> set of locales that have a translated page for that slug.
+    // Slugs include sub-paths (e.g. "guides/top-up", "training/flashcard").
+    const slugLocales = new Map<string, Set<string>>();
+
+    for (const path of Object.keys(pageModules)) {
+        // path looks like "/src/routes/pages/en/guides/top-up.md"
+        const match = path.match(/\/src\/routes\/pages\/([^/]+)\/(.+)\.md$/);
+        if (!match) continue;
+        const [, locale, slug] = match;
+        if (!supportedLocales.includes(locale)) continue;
+        // Skip drafts (filename or any path segment starting with "_")
+        if (slug.split('/').some((seg) => seg.startsWith('_'))) continue;
+
+        if (!slugLocales.has(slug)) slugLocales.set(slug, new Set());
+        slugLocales.get(slug)!.add(locale);
+    }
+
+    const entries: SitemapEntry[] = [];
+
+    // Locale homepages (e.g. /en, /es) — always present, point at docs-home.
+    for (const locale of supportedLocales) {
+        entries.push({
+            loc: `${SITE_URL}/${locale}`,
+            alternates: supportedLocales.map((l) => ({ hreflang: l, href: `${SITE_URL}/${l}` }))
+        });
+    }
+
+    // One entry per (slug, locale) with hreflang alternates pointing to every
+    // other translation that exists.
+    for (const [slug, locales] of slugLocales.entries()) {
+        const alternates = [...locales].sort().map((l) => ({
+            hreflang: l,
+            href: `${SITE_URL}/${l}/${slug}`
+        }));
+        for (const locale of locales) {
+            entries.push({
+                loc: `${SITE_URL}/${locale}/${slug}`,
+                alternates
+            });
+        }
+    }
+
+    return entries;
+}
+
+function escapeXml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
+function renderSitemap(entries: SitemapEntry[]): string {
+    const urls = entries
+        .map((entry) => {
+            const alternates = entry.alternates
+                .map(
+                    (a) =>
+                        `        <xhtml:link rel="alternate" hreflang="${escapeXml(a.hreflang)}" href="${escapeXml(a.href)}" />`
+                )
+                .join('\n');
+            return `    <url>\n        <loc>${escapeXml(entry.loc)}</loc>\n${alternates}\n    </url>`;
+        })
+        .join('\n');
+
+    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset\n    xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n    xmlns:xhtml="http://www.w3.org/1999/xhtml">\n${urls}\n</urlset>\n`;
+}
+
+export const GET: RequestHandler = async () => {
+    const xml = renderSitemap(buildEntries());
+    return new Response(xml, {
+        headers: {
+            'Content-Type': 'application/xml; charset=utf-8',
+            // Sitemap can safely live on the CDN for a day; search engines will
+            // refetch on their own schedule regardless.
+            'Cache-Control': 'public, max-age=3600, s-maxage=86400'
+        }
+    });
+};
+
+export const prerender = true;

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,12 @@
+# https://documentation.getflash.io/robots.txt
+# Flash Documentation crawl rules
+
+User-agent: *
+Allow: /
+
+# Don't index internal/utility routes
+Disallow: /api/
+Disallow: /health
+Disallow: /test/
+
+Sitemap: https://documentation.getflash.io/sitemap.xml


### PR DESCRIPTION
**Files:** 7 changed, +191 / -3

**Why:** Three foundational SEO surfaces were missing.
- `/robots.txt` returned 404 → no crawl guidance for search engines.
- `/sitemap.xml` returned 404 → ~325+ URLs (25 pages × 13 locales) were not discoverable except by crawl.
- No `og:` or `twitter:` meta tags → bare links with no preview cards in WhatsApp / Slack / Telegram / X.
- Existing `hreflang` alternates pointed to `https://flash.how/...` (wrong domain).

**What's in it:**
- `static/robots.txt` — full crawl, disallows `/api`, `/health`, `/test`, points at the sitemap.
- `src/routes/sitemap.xml/+server.ts` — prerendered endpoint that uses `import.meta.glob` to enumerate every `.md` page at build time and emits `<url>` entries with `hreflang` alternates per locale. Skips drafts (`_*`). Cached at the edge for 24h.
- `src/app.html` — site-wide OG/Twitter defaults (`site_name`, `type`, `image`, card type).
- `[locale]/+page.svelte` and all three `[slug]/+page.svelte` templates — add `og:title`, `og:description`, `og:url`, `og:locale`, `twitter:title`, `twitter:description`, `canonical`, and `x-default` hreflang. hreflang base URL corrected to `documentation.getflash.io`.

**Test:**
- `curl https://your-deploy/robots.txt` → 200 with text body.
- `curl https://your-deploy/sitemap.xml` → 200 with valid XML containing all locales.
- Paste a doc URL into Slack / WhatsApp → preview card renders.
